### PR TITLE
Improve hand scoring with comprehensive grouping

### DIFF
--- a/okey_game_simulation.py
+++ b/okey_game_simulation.py
@@ -110,53 +110,104 @@ def distribute_tiles(tiles: List[int]) -> List[List[int]]:
     return hands
 
 
-def score_hand(hand: List[int], okey: int) -> int:
-    """
-    Evaluate a player's hand by counting how many tiles remain ungrouped.
+Tile = Tuple[int, str]
 
-    - Sequences: runs of three consecutive numbers within the same color
-    - Pairs: two identical tile indices
-    - Fake Okey (index 52) substitutes the real Okey
 
-    Args:
-        hand (List[int]): Player's tile indices.
-        okey (int): Index of the Okey tile.
+def _generate_all_groups(tiles: List[Tile], jokers: List[Tile]) -> List[List[Tile]]:
+    """Generate candidate groups of tiles using jokers as wildcards."""
+    groups: List[List[Tile]] = []
 
-    Returns:
-        int: Number of tiles not included in any valid group.
-    """
-    # Replace fake Okey with actual Okey
-    normalized = [okey if t == FAKE_OKEY_INDEX else t for t in hand]
-    used = 0
+    num_to_tiles: Dict[int, List[Tile]] = defaultdict(list)
+    color_to_nums: Dict[str, set] = defaultdict(set)
+    for t in tiles:
+        num_to_tiles[t[0]].append(t)
+        color_to_nums[t[1]].add(t[0])
 
-    # Sequence detection by color
-    color_groups: Dict[str, List[int]] = defaultdict(list)
-    for tile in normalized:
-        color = get_color(tile)
-        num = get_number(tile)
-        if color != 'fake' and num is not None:
-            color_groups[color].append(num)
+    # Full SET groups (same number, different colors)
+    for num, same_num_tiles in num_to_tiles.items():
+        unique_tiles: List[Tile] = []
+        seen_colors = set()
+        for t in same_num_tiles:
+            if t[1] not in seen_colors:
+                seen_colors.add(t[1])
+                unique_tiles.append(t)
+        for target_size in (3, 4):
+            missing = target_size - len(unique_tiles)
+            if 0 <= missing <= len(jokers) and len(unique_tiles) + len(jokers) >= 3:
+                groups.append(unique_tiles + jokers[:missing])
 
-    for nums in color_groups.values():
-        counts = Counter(nums)
-        unique_nums = sorted(counts)
-        i = 0
-        while i + 2 < len(unique_nums):
-            a, b, c = unique_nums[i], unique_nums[i + 1], unique_nums[i + 2]
-            if b == a + 1 and c == b + 1 and counts[a] and counts[b] and counts[c]:
-                used += 3
-                counts[a] -= 1
-                counts[b] -= 1
-                counts[c] -= 1
+    # Full RUN groups (same color, consecutive numbers)
+    for color, nums in color_to_nums.items():
+        nums = sorted(nums)
+        for target_size in (3, 4):
+            for start in range(1, 14 - target_size + 1):
+                window = list(range(start, start + target_size))
+                present = [(n, color) for n in window if n in nums]
+                missing = target_size - len(present)
+                if 0 <= missing <= len(jokers) and len(present) >= 1:
+                    groups.append(present + jokers[:missing])
+
+    # Partial SET groups (2 tiles, same number)
+    for num, same_num_tiles in num_to_tiles.items():
+        if len(same_num_tiles) >= 2:
+            groups.append(same_num_tiles[:2])
+
+    # Partial RUN groups (2 tiles, same color)
+    for color, nums in color_to_nums.items():
+        sorted_nums = sorted(nums)
+        for i in range(len(sorted_nums) - 1):
+            if sorted_nums[i + 1] - sorted_nums[i] == 1:
+                groups.append([(sorted_nums[i], color), (sorted_nums[i + 1], color)])
+
+    unique: List[List[Tile]] = []
+    seen = set()
+    for g in groups:
+        key = tuple(sorted(g))
+        if key not in seen:
+            seen.add(key)
+            unique.append(g)
+    return unique
+
+
+def _find_best_grouping(hand: List[Tile], okey_tile: Optional[Tile] = None) -> Tuple[List[List[Tile]], List[Tile]]:
+    """Use backtracking to find grouping that leaves fewest tiles ungrouped."""
+    jokers = [t for t in hand if okey_tile is not None and t == okey_tile]
+    tiles = [t for t in hand if t not in jokers]
+
+    all_groups = _generate_all_groups(tiles, jokers)
+
+    best_groups: List[List[Tile]] = []
+    best_remaining: List[Tile] = hand[:]
+
+    def backtrack(chosen: List[List[Tile]], used: List[Tile]) -> None:
+        nonlocal best_groups, best_remaining
+        remaining = [t for t in hand if t not in used]
+        if len(remaining) < len(best_remaining):
+            best_remaining = remaining[:]
+            best_groups = chosen[:]
+        for g in all_groups:
+            if any(tile in used for tile in g):
                 continue
-            i += 1
+            backtrack(chosen + [g], used + g)
 
-    # Pair detection by exact tile
-    tile_counts = Counter(normalized)
-    for count in tile_counts.values():
-        used += (count // 2) * 2
+    backtrack([], [])
+    return best_groups, best_remaining
 
-    return len(hand) - used
+
+def score_hand(hand: List[int], okey: int) -> int:
+    """Return the number of ungrouped tiles in ``hand`` using an exhaustive grouping strategy."""
+
+    def as_tile(idx: int) -> Tile:
+        tile_index = okey if idx == FAKE_OKEY_INDEX else idx
+        num = get_number(tile_index)
+        color = get_color(tile_index)
+        return (num or 0, color)
+
+    tiles = [as_tile(t) for t in hand]
+    joker_tile = as_tile(okey)
+
+    _, remaining = _find_best_grouping(tiles, okey_tile=joker_tile)
+    return len(remaining)
 
 
 def main() -> None:

--- a/tests/test_okey_game_simulation.py
+++ b/tests/test_okey_game_simulation.py
@@ -96,9 +96,9 @@ def test_score_hand_sequence_and_pair():
 
 def test_score_hand_no_groups():
     """
-    A hand with no possible sequence or pair
-    should have all tiles leftover.
+    A hand containing four tiles of the same number but different colors forms
+    a valid set, leaving no tiles ungrouped.
     """
     hand = [0, 13, 26, 39]
     leftover = score_hand(hand, okey=FAKE_OKEY_INDEX)
-    assert leftover == len(hand), f"Expected {len(hand)} leftover, got {leftover}"
+    assert leftover == 0, f"Expected 0 leftover, got {leftover}"


### PR DESCRIPTION
## Summary
- add extensive grouping logic for scoring hands
- treat same-number different-color sets as valid groups
- adjust tests to match new scoring rules

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499095ac98832ca99a63b56e9f7b41