### PR TITLE
Fix duplicate tile handling and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,3 @@ pytest --maxfail=1 --disable-warnings -q
 - Customize the log level or format by editing the `logging.basicConfig` call in `okey_game_simulation.py`.
 
 ---
-# okey-game-simulation

--- a/tests/test_okey_game_simulation.py
+++ b/tests/test_okey_game_simulation.py
@@ -102,3 +102,10 @@ def test_score_hand_no_groups():
     hand = [0, 13, 26, 39]
     leftover = score_hand(hand, okey=FAKE_OKEY_INDEX)
     assert leftover == 0, f"Expected 0 leftover, got {leftover}"
+
+
+def test_duplicate_tiles_used_separately():
+    """Two identical tiles should be usable in different groups."""
+    hand = [0, 0, 13, 26, 39]
+    leftover = score_hand(hand, okey=FAKE_OKEY_INDEX)
+    assert leftover == 0


### PR DESCRIPTION
## Summary
- drop stray footer lines from README
- ensure indicator tile is removed from the deck
- represent tiles with unique ids to allow duplicate usage
- adjust grouping logic for copies and add new tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_684993931284832c9d2ff91af2779843